### PR TITLE
fix: props of drawer

### DIFF
--- a/contents/components/overlay/drawer/index.ja.mdx
+++ b/contents/components/overlay/drawer/index.ja.mdx
@@ -107,7 +107,7 @@ return (
 
 ### 位置を変更する
 
-表示位置を変更するには、`placement`に`top`や`left-start`などを設定します。デフォルトでは、`bottom`が設定されています。
+表示位置を変更するには、`placement`に`top`や`left-start`などを設定します。デフォルトでは、`right`が設定されています。
 
 ```tsx functional=true
 const placementMap = ["top", "right", "bottom", "left"]

--- a/contents/components/overlay/drawer/index.mdx
+++ b/contents/components/overlay/drawer/index.mdx
@@ -107,7 +107,7 @@ return (
 
 ### Change Position
 
-To change the display position, set `placement` to values like `top` or `left-start`. By default, `bottom` is set.
+To change the display position, set `placement` to values like `top` or `left-start`. By default, `right` is set.
 
 ```tsx functional=true
 const placementMap = ["top", "right", "bottom", "left"]

--- a/contents/components/overlay/drawer/props.ja.mdx
+++ b/contents/components/overlay/drawer/props.ja.mdx
@@ -1403,7 +1403,7 @@ tab: Props
   | "bottom-right"> &
   UIValue<"bottom" | "left" | "right" | "top">'
   description={"The placement of the modal.\n\n\nThe placement of the drawer."}
-  defaultValue={"'center'"}
+  defaultValue={"'right'"}
 />
 
 <PropsCard

--- a/contents/components/overlay/drawer/props.mdx
+++ b/contents/components/overlay/drawer/props.mdx
@@ -1403,7 +1403,7 @@ tab: Props
   | "bottom-right"> &
   UIValue<"bottom" | "left" | "right" | "top">'
   description={"The placement of the modal.\n\n\nThe placement of the drawer."}
-  defaultValue={"'center'"}
+  defaultValue={"'right'"}
 />
 
 <PropsCard


### PR DESCRIPTION
Closes #187 

## Description
In the drawer component, the placement of the drawer can be configured.
According to the documentation, the default placement of the props is at the `bottom`.
However, in the actual source code, the props placement is set to the `right`.
![image](https://github.com/yamada-ui/yamada-docs/assets/83833293/4f87b208-5ac4-473c-9301-f6a06d59b577)
https://github.com/yamada-ui/yamada-ui/blob/main/packages/components/modal/src/drawer.tsx#L67

## Current behavior (updates)

```markdown
By default, `bottom` is set.
```
```markdown
defaultValue={"'bottom'"}
```
## New behavior

```markdown
By default, `right` is set.
```
```markdown
defaultValue={"'right'"}
```
## Is this a breaking change (Yes/No):

No

## Additional Information
No