### PR TITLE
docs(textarea): remove autosize in textarea resizeRef documentation

### DIFF
--- a/contents/components/forms/textarea/index.ja.mdx
+++ b/contents/components/forms/textarea/index.ja.mdx
@@ -82,7 +82,7 @@ const onResize = () => {
 return (
   <>
     <VStack>
-      <Textarea autosize placeholder="use resize" resizeRef={resizeRef} />
+      <Textarea placeholder="use resize" resizeRef={resizeRef} />
 
       <Button alignSelf="flex-end" onClick={onResize}>
         Resize

--- a/contents/components/forms/textarea/index.mdx
+++ b/contents/components/forms/textarea/index.mdx
@@ -82,7 +82,7 @@ const onResize = () => {
 return (
   <>
     <VStack>
-      <Textarea autosize placeholder="use resize" resizeRef={resizeRef} />
+      <Textarea placeholder="use resize" resizeRef={resizeRef} />
 
       <Button alignSelf="flex-end" onClick={onResize}>
         Resize


### PR DESCRIPTION
## Description

Autosize is not required in the resizeRef example.

## Current behavior (updates)

```tsx
<Textarea autosize placeholder="use resize" resizeRef={resizeRef} />
```

## New behavior

```tsx
<Textarea placeholder="use resize" resizeRef={resizeRef} />
```

## Is this a breaking change (Yes/No):

No