### PR TITLE
fix: add :where property to `_weekend` and `_outside` in pseudo

### DIFF
--- a/contents/styled-system/style-props.ja.mdx
+++ b/contents/styled-system/style-props.ja.mdx
@@ -580,7 +580,7 @@ with_children_description: false
 | `_notLast`             | `&:not(:last-of-type)`                                                                   | none             |
 | `_notTarget`           | `&:not(:target)`                                                                         | none             |
 | `_odd`                 | `&:nth-of-type(odd)`                                                                     | none             |
-| `_outside`             | `&[data-outside]`                                                                        | none             |
+| `_outside`             | `&:where([data-outside])`                                                                        | none             |
 | `_placeholder`         | `&::placeholder, &[data-placeholder]`                                                    | none             |
 | `_placeholderShown`    | `&:placeholder-shown`                                                                    | none             |
 | `_readOnly`            | `&[readonly], &[aria-readonly=true], &[data-readonly]`                                   | none             |
@@ -600,4 +600,4 @@ with_children_description: false
 | `_valid`               | `&:valid, &[data-valid], &[data-state=valid]`                                            | none             |
 | `_vertical`            | `&:vertical, &[data-orientation=vertical]`                                               | none             |
 | `_visited`             | `&:visited`                                                                              | none             |
-| `_weekend`             | `&[data-weekend]`                                                                        | none             |
+| `_weekend`             | `&:where([data-weekend])`                                                                        | none             |

--- a/contents/styled-system/style-props.ja.mdx
+++ b/contents/styled-system/style-props.ja.mdx
@@ -580,7 +580,7 @@ with_children_description: false
 | `_notLast`             | `&:not(:last-of-type)`                                                                   | none             |
 | `_notTarget`           | `&:not(:target)`                                                                         | none             |
 | `_odd`                 | `&:nth-of-type(odd)`                                                                     | none             |
-| `_outside`             | `&:where([data-outside])`                                                                        | none             |
+| `_outside`             | `&:where([data-outside])`                                                                | none             |
 | `_placeholder`         | `&::placeholder, &[data-placeholder]`                                                    | none             |
 | `_placeholderShown`    | `&:placeholder-shown`                                                                    | none             |
 | `_readOnly`            | `&[readonly], &[aria-readonly=true], &[data-readonly]`                                   | none             |
@@ -600,4 +600,4 @@ with_children_description: false
 | `_valid`               | `&:valid, &[data-valid], &[data-state=valid]`                                            | none             |
 | `_vertical`            | `&:vertical, &[data-orientation=vertical]`                                               | none             |
 | `_visited`             | `&:visited`                                                                              | none             |
-| `_weekend`             | `&:where([data-weekend])`                                                                        | none             |
+| `_weekend`             | `&:where([data-weekend])`                                                                | none             |

--- a/contents/styled-system/style-props.mdx
+++ b/contents/styled-system/style-props.mdx
@@ -580,7 +580,7 @@ When using `translateX`, `scale`, `skewX`, etc., you need to set `auto` or `auto
 | `_notLast`             | `&:not(:last-of-type)`                                                                   | none         |
 | `_notTarget`           | `&:not(:target)`                                                                         | none         |
 | `_odd`                 | `&:nth-of-type(odd)`                                                                     | none         |
-| `_outside`             | `&:where([data-outside])`                                                                        | none         |
+| `_outside`             | `&:where([data-outside])`                                                                | none         |
 | `_placeholder`         | `&::placeholder, &[data-placeholder]`                                                    | none         |
 | `_placeholderShown`    | `&:placeholder-shown`                                                                    | none         |
 | `_readOnly`            | `&[readonly], &[aria-readonly=true], &[data-readonly]`                                   | none         |
@@ -600,4 +600,4 @@ When using `translateX`, `scale`, `skewX`, etc., you need to set `auto` or `auto
 | `_valid`               | `&:valid, &[data-valid], &[data-state=valid]`                                            | none         |
 | `_vertical`            | `&:vertical, &[data-orientation=vertical]`                                               | none         |
 | `_visited`             | `&:visited`                                                                              | none         |
-| `_weekend`             | `&:where([data-weekend])`                                                                        | none         |
+| `_weekend`             | `&:where([data-weekend])`                                                                | none         |

--- a/contents/styled-system/style-props.mdx
+++ b/contents/styled-system/style-props.mdx
@@ -580,7 +580,7 @@ When using `translateX`, `scale`, `skewX`, etc., you need to set `auto` or `auto
 | `_notLast`             | `&:not(:last-of-type)`                                                                   | none         |
 | `_notTarget`           | `&:not(:target)`                                                                         | none         |
 | `_odd`                 | `&:nth-of-type(odd)`                                                                     | none         |
-| `_outside`             | `&[data-outside]`                                                                        | none         |
+| `_outside`             | `&:where([data-outside])`                                                                        | none         |
 | `_placeholder`         | `&::placeholder, &[data-placeholder]`                                                    | none         |
 | `_placeholderShown`    | `&:placeholder-shown`                                                                    | none         |
 | `_readOnly`            | `&[readonly], &[aria-readonly=true], &[data-readonly]`                                   | none         |
@@ -600,4 +600,4 @@ When using `translateX`, `scale`, `skewX`, etc., you need to set `auto` or `auto
 | `_valid`               | `&:valid, &[data-valid], &[data-state=valid]`                                            | none         |
 | `_vertical`            | `&:vertical, &[data-orientation=vertical]`                                               | none         |
 | `_visited`             | `&:visited`                                                                              | none         |
-| `_weekend`             | `&[data-weekend]`                                                                        | none         |
+| `_weekend`             | `&:where([data-weekend])`                                                                        | none         |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #199 

## Description

update pseudos `_weekend`, `_outside` properties

## Current behavior (updates)

```mdx
| `_weekend`             | `&[data-weekend]`                                                                | none         |
| `_outside`             | `&[data-outside]`                                                                | none         |
```

## New behavior

```mdx
| `_weekend`             | `&:where([data-weekend])`                                                                | none         |
| `_outside`             | `&:where([data-outside])`                                                                | none         |
```

## Is this a breaking change (Yes/No):

No

## Additional Information
