### PR TITLE
Fixed the issue where `useWindowEvent` hook cannot be tested

### DIFF
--- a/contents/hooks/use-window-event.ja.mdx
+++ b/contents/hooks/use-window-event.ja.mdx
@@ -18,7 +18,7 @@ import { useWindowEvent } from "@yamada-ui/react"
 const [count, setCount] = useState(0)
 
 useWindowEvent("click", () => {
-  setCount(count + 1)
+  setCount((prev) => prev + 1)
 })
 
 return <Text>{count}回クリックしました。</Text>

--- a/contents/hooks/use-window-event.ja.mdx
+++ b/contents/hooks/use-window-event.ja.mdx
@@ -2,6 +2,7 @@
 title: useWindowEvent
 description: "`useWindowEvent`は、`window`へ指定されたイベントリスナーを割り当てるカスタムフックです。"
 package_name: "@yamada-ui/use-window-event"
+label: Updated
 with_description: true
 ---
 
@@ -14,23 +15,11 @@ import { useWindowEvent } from "@yamada-ui/react"
 ## 使い方
 
 ```tsx functional=true
-const inputRef = useRef<HTMLInputElement>(null)
+const [count, setCount] = useState(0)
 
-useWindowEvent("keydown", (ev) => {
-  if (ev.code === "KeyK" && (ev.ctrlKey || ev.metaKey)) {
-    ev.preventDefault()
-
-    if (inputRef.current) inputRef.current.focus()
-  }
+useWindowEvent("click", () => {
+  setCount(count + 1)
 })
 
-return (
-  <>
-    <Text>
-      Focus: <Kbd>Ctrl + K</Kbd>
-    </Text>
-
-    <Input ref={inputRef} mt="md" />
-  </>
-)
+return <Text>{count}回クリックしました。</Text>
 ```

--- a/contents/hooks/use-window-event.mdx
+++ b/contents/hooks/use-window-event.mdx
@@ -2,6 +2,7 @@
 title: useWindowEvent
 description: "`useWindowEvent` is a custom hook that assigns an event listener to `window`."
 package_name: "@yamada-ui/use-window-event"
+label: Updated
 with_description: true
 ---
 
@@ -14,23 +15,11 @@ import { useWindowEvent } from "@yamada-ui/react"
 ## Usage
 
 ```tsx functional=true
-const inputRef = useRef<HTMLInputElement>(null)
+const [count, setCount] = useState(0)
 
-useWindowEvent("keydown", (ev) => {
-  if (ev.code === "KeyK" && (ev.ctrlKey || ev.metaKey)) {
-    ev.preventDefault()
-
-    if (inputRef.current) inputRef.current.focus()
-  }
+useWindowEvent("click", () => {
+  setCount(count + 1)
 })
 
-return (
-  <>
-    <Text>
-      Focus: <Kbd>Ctrl + K</Kbd>
-    </Text>
-
-    <Input ref={inputRef} mt="md" />
-  </>
-)
+return <Text>Click count: {count}</Text>
 ```

--- a/contents/hooks/use-window-event.mdx
+++ b/contents/hooks/use-window-event.mdx
@@ -18,7 +18,7 @@ import { useWindowEvent } from "@yamada-ui/react"
 const [count, setCount] = useState(0)
 
 useWindowEvent("click", () => {
-  setCount(count + 1)
+  setCount((prev) => prev + 1)
 })
 
 return <Text>Click count: {count}</Text>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #229 

## Description

Changed to be a click counter rather than shortcut key.

## Current behavior (updates)

It was a shortcut key (ctrl + k) that would focus on an input. This shortcut was already being used to focus on the search bar.

## New behavior

It is now a window click counter.

## Is this a breaking change (Yes/No):

No