### PR TITLE
Fix URL `styled-system/theming/component-style`

### DIFF
--- a/contents/components/data-display/badge/theming.ja.mdx
+++ b/contents/components/data-display/badge/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Badge`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Badge`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/badge/theming.mdx
+++ b/contents/components/data-display/badge/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Badge` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Badge` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/calendar/theming.ja.mdx
+++ b/contents/components/data-display/calendar/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`Calendar`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Calendar`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/calendar/theming.mdx
+++ b/contents/components/data-display/calendar/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `Calendar` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Calendar` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/card/theming.ja.mdx
+++ b/contents/components/data-display/card/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Card`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Card`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/card/theming.mdx
+++ b/contents/components/data-display/card/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Card` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Card` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/carousel/theming.ja.mdx
+++ b/contents/components/data-display/carousel/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Carousel`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Carousel`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/carousel/theming.mdx
+++ b/contents/components/data-display/carousel/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Carousel` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Carousel` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/color-swatch/theming.ja.mdx
+++ b/contents/components/data-display/color-swatch/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`ColorSwatch`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`ColorSwatch`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/color-swatch/theming.mdx
+++ b/contents/components/data-display/color-swatch/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `ColorSwatch` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `ColorSwatch` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/kbd/theming.ja.mdx
+++ b/contents/components/data-display/kbd/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Kbd`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Kbd`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/kbd/theming.mdx
+++ b/contents/components/data-display/kbd/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Kbd` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Kbd` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/list/theming.ja.mdx
+++ b/contents/components/data-display/list/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`List`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`List`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/list/theming.mdx
+++ b/contents/components/data-display/list/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `List` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `List` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/markdown/theming.ja.mdx
+++ b/contents/components/data-display/markdown/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Markdown`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Markdown`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/markdown/theming.mdx
+++ b/contents/components/data-display/markdown/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Markdown` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Markdown` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/native-table/theming.ja.mdx
+++ b/contents/components/data-display/native-table/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`NativeTable`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`NativeTable`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/native-table/theming.mdx
+++ b/contents/components/data-display/native-table/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `NativeTable` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `NativeTable` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/paging-table/theming.ja.mdx
+++ b/contents/components/data-display/paging-table/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`PagingTable`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`PagingTable`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `PagingTable`は、[Table](/components/data-display/table)のスタイルを継承しています。

--- a/contents/components/data-display/paging-table/theming.mdx
+++ b/contents/components/data-display/paging-table/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `PagingTable` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `PagingTable` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `PagingTable` inherits the style from [Table](/components/data-display/table).

--- a/contents/components/data-display/reorder/theming.ja.mdx
+++ b/contents/components/data-display/reorder/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Reorder`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Reorder`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/reorder/theming.mdx
+++ b/contents/components/data-display/reorder/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Reorder` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Reorder` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/resizable/theming.ja.mdx
+++ b/contents/components/data-display/resizable/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`Resizable`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Resizable`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/resizable/theming.mdx
+++ b/contents/components/data-display/resizable/theming.mdx
@@ -11,7 +11,7 @@ tab: Theming
 
 ## Theming
 
-The `Resizable` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Resizable` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/scroll-area/theming.ja.mdx
+++ b/contents/components/data-display/scroll-area/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`ScrollArea`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`ScrollArea`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/scroll-area/theming.mdx
+++ b/contents/components/data-display/scroll-area/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `ScrollArea` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `ScrollArea` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/stat/theming.ja.mdx
+++ b/contents/components/data-display/stat/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Stat`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Stat`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/stat/theming.mdx
+++ b/contents/components/data-display/stat/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Stat` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Stat` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/data-display/table/theming.ja.mdx
+++ b/contents/components/data-display/table/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Table`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Table`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `Table`は、[NativeTable](/components/data-display/native-table)のスタイルを継承しています。

--- a/contents/components/data-display/table/theming.mdx
+++ b/contents/components/data-display/table/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Table` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Table` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `Table` inherits the style from [NativeTable](/components/data-display/native-table).

--- a/contents/components/data-display/tag/theming.ja.mdx
+++ b/contents/components/data-display/tag/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Tag`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Tag`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/data-display/tag/theming.mdx
+++ b/contents/components/data-display/tag/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Tag` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Tag` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/disclosure/accordion/theming.ja.mdx
+++ b/contents/components/disclosure/accordion/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Accordion`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Accordion`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/disclosure/accordion/theming.mdx
+++ b/contents/components/disclosure/accordion/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Accordion` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Accordion` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/disclosure/tabs/theming.ja.mdx
+++ b/contents/components/disclosure/tabs/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Tabs`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Tabs`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/disclosure/tabs/theming.mdx
+++ b/contents/components/disclosure/tabs/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Tabs` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Tabs` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/feedback/alert/theming.ja.mdx
+++ b/contents/components/feedback/alert/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Alert`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Alert`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/feedback/alert/theming.mdx
+++ b/contents/components/feedback/alert/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Alert` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Alert` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/feedback/progress/theming.ja.mdx
+++ b/contents/components/feedback/progress/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Progress`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Progress`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/feedback/progress/theming.mdx
+++ b/contents/components/feedback/progress/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Progress` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Progress` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/feedback/skeleton/theming.ja.mdx
+++ b/contents/components/feedback/skeleton/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Skeleton`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Skeleton`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/feedback/skeleton/theming.mdx
+++ b/contents/components/feedback/skeleton/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Skeleton` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Skeleton` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/alpha-slider/theming.ja.mdx
+++ b/contents/components/forms/alpha-slider/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`AlphaSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`AlphaSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `AlphaSlider`は、[HueSlider](/components/forms/hue-slider)のスタイルを継承しています。

--- a/contents/components/forms/alpha-slider/theming.mdx
+++ b/contents/components/forms/alpha-slider/theming.mdx
@@ -11,7 +11,7 @@ tab: Theming
 
 ## Theming
 
-The `AlphaSlider` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `AlphaSlider` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `AlphaSlider` inherits the style from [HueSlider](/components/forms/hue-slider).

--- a/contents/components/forms/autocomplete/theming.ja.mdx
+++ b/contents/components/forms/autocomplete/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Autocomplete`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Autocomplete`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `Autocomplete`は、[Select](/components/forms/select)のスタイルを継承しています。

--- a/contents/components/forms/autocomplete/theming.mdx
+++ b/contents/components/forms/autocomplete/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Autocomplete` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Autocomplete` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `Autocomplete` inherits the style from [Select](/components/forms/select).

--- a/contents/components/forms/button/theming.ja.mdx
+++ b/contents/components/forms/button/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Button`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Button`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/button/theming.mdx
+++ b/contents/components/forms/button/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Button` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Button` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/checkbox/theming.ja.mdx
+++ b/contents/components/forms/checkbox/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Checkbox`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Checkbox`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/checkbox/theming.mdx
+++ b/contents/components/forms/checkbox/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Checkbox` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Checkbox` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/color-picker/theming.ja.mdx
+++ b/contents/components/forms/color-picker/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`ColorPicker`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`ColorPicker`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 `ColorPicker`は、[Input](/components/forms/input)と[Menu](/components/overlay/menu)のスタイルを継承しています。

--- a/contents/components/forms/color-picker/theming.mdx
+++ b/contents/components/forms/color-picker/theming.mdx
@@ -11,7 +11,7 @@ tab: Theming
 
 ## Theming
 
-The `ColorPicker` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `ColorPicker` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 `ColorPicker` inherits the style from [Input](/components/forms/input) and [Menu](/components/overlay/menu).

--- a/contents/components/forms/date-picker/theming.ja.mdx
+++ b/contents/components/forms/date-picker/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`DatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`DatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `DatePicker`は、[Input](/components/forms/input)と[MultiSelect](/components/forms/multi-select)のスタイルを継承しています。

--- a/contents/components/forms/date-picker/theming.mdx
+++ b/contents/components/forms/date-picker/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `DatePicker` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `DatePicker` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `DatePicker` inherits the style from [Input](/components/forms/input) and [MultiSelect](/components/forms/multi-select).

--- a/contents/components/forms/dropzone/theming.ja.mdx
+++ b/contents/components/forms/dropzone/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Dropzone`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Dropzone`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/dropzone/theming.mdx
+++ b/contents/components/forms/dropzone/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Dropzone` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Dropzone` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/editable/theming.ja.mdx
+++ b/contents/components/forms/editable/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Editable`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Editable`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/editable/theming.mdx
+++ b/contents/components/forms/editable/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Editable` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Editable` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/file-input/theming.ja.mdx
+++ b/contents/components/forms/file-input/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`FileInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`FileInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `FileInput`は、[Input](/components/forms/input)のスタイルを継承しています。

--- a/contents/components/forms/file-input/theming.mdx
+++ b/contents/components/forms/file-input/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `FileInput` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `FileInput` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `FileInput` inherits the style from [Input](/components/forms/input).

--- a/contents/components/forms/form-control/theming.ja.mdx
+++ b/contents/components/forms/form-control/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`FormControl`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`FormControl`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/form-control/theming.mdx
+++ b/contents/components/forms/form-control/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `FormControl` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `FormControl` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/hue-slider/theming.ja.mdx
+++ b/contents/components/forms/hue-slider/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`HueSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`HueSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/hue-slider/theming.mdx
+++ b/contents/components/forms/hue-slider/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `HueSlider` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `HueSlider` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/input/theming.ja.mdx
+++ b/contents/components/forms/input/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Input`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Input`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/input/theming.mdx
+++ b/contents/components/forms/input/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Input` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Input` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/month-picker/theming.ja.mdx
+++ b/contents/components/forms/month-picker/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`MonthPicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`MonthPicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `MonthPicker`は、[DatePicker](/components/forms/date-picker)のスタイルを継承しています。

--- a/contents/components/forms/month-picker/theming.mdx
+++ b/contents/components/forms/month-picker/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `MonthPicker` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `MonthPicker` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `MonthPicker` inherits the style from [DatePicker](/components/forms/date-picker).

--- a/contents/components/forms/multi-autocomplete/theming.ja.mdx
+++ b/contents/components/forms/multi-autocomplete/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`MultiAutocomplete`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`MultiAutocomplete`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `MultiAutocomplete`は、[MultiSelect](/components/forms/multi-select)のスタイルを継承しています。

--- a/contents/components/forms/multi-autocomplete/theming.mdx
+++ b/contents/components/forms/multi-autocomplete/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `MultiAutocomplete` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `MultiAutocomplete` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `MultiAutocomplete` inherits the style from [MultiSelect](/components/forms/multi-select).

--- a/contents/components/forms/multi-date-picker/theming.ja.mdx
+++ b/contents/components/forms/multi-date-picker/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`MultiDatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`MultiDatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `MultiDatePicker`は、[DatePicker](/components/forms/date-picker)のスタイルを継承しています。

--- a/contents/components/forms/multi-date-picker/theming.mdx
+++ b/contents/components/forms/multi-date-picker/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `MultiDatePicker` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `MultiDatePicker` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `MultiDatePicker` inherits the style from [DatePicker](/components/forms/date-picker).

--- a/contents/components/forms/multi-select/theming.ja.mdx
+++ b/contents/components/forms/multi-select/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`MultiSelect`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`MultiSelect`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `MultiSelect`は、[Select](/components/forms/select)のスタイルを継承しています。

--- a/contents/components/forms/multi-select/theming.mdx
+++ b/contents/components/forms/multi-select/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `MultiSelect` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `MultiSelect` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `MultiSelect` inherits the style from [Select](/components/forms/select).

--- a/contents/components/forms/native-select/theming.ja.mdx
+++ b/contents/components/forms/native-select/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`NativeSelect`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`NativeSelect`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `NativeSelect`は、[Input](/components/forms/input)のスタイルを継承しています。

--- a/contents/components/forms/native-select/theming.mdx
+++ b/contents/components/forms/native-select/theming.mdx
@@ -11,7 +11,7 @@ tab: Theming
 
 ## Theming
 
-The `NativeSelect` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `NativeSelect` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `NativeSelect` inherits the style from [Input](/components/forms/input).

--- a/contents/components/forms/number-input/theming.ja.mdx
+++ b/contents/components/forms/number-input/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`NumberInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`NumberInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `NumberInput`は、[Input](/components/forms/input)のスタイルを継承しています。

--- a/contents/components/forms/number-input/theming.mdx
+++ b/contents/components/forms/number-input/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `NumberInput` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `NumberInput` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `NumberInput` inherits the style from [Input](/components/forms/input).

--- a/contents/components/forms/pin-input/theming.ja.mdx
+++ b/contents/components/forms/pin-input/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`PinInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`PinInput`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `PinInput`は、[Input](/components/forms/input)のスタイルを継承しています。

--- a/contents/components/forms/pin-input/theming.mdx
+++ b/contents/components/forms/pin-input/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `PinInput` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `PinInput` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `PinInput` inherits the style from [Input](/components/forms/input).

--- a/contents/components/forms/radio/theming.ja.mdx
+++ b/contents/components/forms/radio/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Radio`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Radio`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/radio/theming.mdx
+++ b/contents/components/forms/radio/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Radio` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Radio` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/range-date-picker/theming.ja.mdx
+++ b/contents/components/forms/range-date-picker/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`RangeDatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`RangeDatePicker`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `RangeDatePicker`は、[DatePicker](/components/forms/date-picker)のスタイルを継承しています。

--- a/contents/components/forms/range-date-picker/theming.mdx
+++ b/contents/components/forms/range-date-picker/theming.mdx
@@ -9,7 +9,7 @@ tab: Theming
 
 ## Theming
 
-The `RangeDatePicker` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `RangeDatePicker` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `RangeDatePicker` inherits the style from [DatePicker](/components/forms/date-picker).

--- a/contents/components/forms/range-slider/theming.ja.mdx
+++ b/contents/components/forms/range-slider/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`RangeSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`RangeSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `RangeSlider`は、[Slider](/components/forms/slider)のスタイルを継承しています。

--- a/contents/components/forms/range-slider/theming.mdx
+++ b/contents/components/forms/range-slider/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `RangeSlider` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `RangeSlider` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `RangeSlider` inherits the style from [Slider](/components/forms/slider).

--- a/contents/components/forms/rating/theming.ja.mdx
+++ b/contents/components/forms/rating/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Rating`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Rating`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/rating/theming.mdx
+++ b/contents/components/forms/rating/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Rating` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Rating` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/saturation-slider/theming.ja.mdx
+++ b/contents/components/forms/saturation-slider/theming.ja.mdx
@@ -9,7 +9,7 @@ tab: テーマ
 
 ## テーマ
 
-`SaturationSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`SaturationSlider`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/saturation-slider/theming.mdx
+++ b/contents/components/forms/saturation-slider/theming.mdx
@@ -11,7 +11,7 @@ tab: Theming
 
 ## Theming
 
-The `SaturationSlider` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `SaturationSlider` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/segmented-control/theming.ja.mdx
+++ b/contents/components/forms/segmented-control/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`SegmentedControl`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`SegmentedControl`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/segmented-control/theming.mdx
+++ b/contents/components/forms/segmented-control/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `SegmentedControl` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `SegmentedControl` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/select/theming.ja.mdx
+++ b/contents/components/forms/select/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Select`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Select`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 `Select`は、[NativeSelect](/components/forms/native-select)と[Menu](/components/overlay/menu)のスタイルを継承しています。

--- a/contents/components/forms/select/theming.mdx
+++ b/contents/components/forms/select/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Select` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Select` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 `Select` inherits the style from [NativeSelect](/components/forms/native-select) and [Menu](/components/overlay/menu).

--- a/contents/components/forms/slider/theming.ja.mdx
+++ b/contents/components/forms/slider/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Slider`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Slider`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/slider/theming.mdx
+++ b/contents/components/forms/slider/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Slider` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Slider` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/switch/theming.ja.mdx
+++ b/contents/components/forms/switch/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Switch`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Switch`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/forms/switch/theming.mdx
+++ b/contents/components/forms/switch/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Switch` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Switch` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/forms/textarea/theming.ja.mdx
+++ b/contents/components/forms/textarea/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Textarea`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Textarea`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 `Textarea`は、[Input](/components/forms/input)のスタイルを継承しています。

--- a/contents/components/forms/textarea/theming.mdx
+++ b/contents/components/forms/textarea/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Textarea` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Textarea` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 `Textarea` inherits the style from [Input](/components/forms/input).

--- a/contents/components/layouts/container/theming.ja.mdx
+++ b/contents/components/layouts/container/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Container`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Container`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/layouts/container/theming.mdx
+++ b/contents/components/layouts/container/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Container` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Container` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/layouts/divider/theming.ja.mdx
+++ b/contents/components/layouts/divider/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Divider`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Divider`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/layouts/divider/theming.mdx
+++ b/contents/components/layouts/divider/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Divider` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Divider` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/media-and-icons/avatar/theming.ja.mdx
+++ b/contents/components/media-and-icons/avatar/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Avatar`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Avatar`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/media-and-icons/avatar/theming.mdx
+++ b/contents/components/media-and-icons/avatar/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Avatar` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Avatar` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/media-and-icons/indicator/theming.ja.mdx
+++ b/contents/components/media-and-icons/indicator/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Indicator`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Indicator`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/media-and-icons/indicator/theming.mdx
+++ b/contents/components/media-and-icons/indicator/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Indicator` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Indicator` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/navigation/breadcrumb/theming.ja.mdx
+++ b/contents/components/navigation/breadcrumb/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Breadcrumb`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Breadcrumb`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/navigation/breadcrumb/theming.mdx
+++ b/contents/components/navigation/breadcrumb/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Breadcrumb` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Breadcrumb` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/navigation/link/theming.ja.mdx
+++ b/contents/components/navigation/link/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Link`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Link`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/navigation/link/theming.mdx
+++ b/contents/components/navigation/link/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Link` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Link` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/navigation/pagination/theming.ja.mdx
+++ b/contents/components/navigation/pagination/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Pagination`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Pagination`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/navigation/pagination/theming.mdx
+++ b/contents/components/navigation/pagination/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Pagination` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Pagination` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/navigation/stepper/theming.ja.mdx
+++ b/contents/components/navigation/stepper/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Stepper`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Stepper`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/navigation/stepper/theming.mdx
+++ b/contents/components/navigation/stepper/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Stepper` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Stepper` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/other/close-button/theming.ja.mdx
+++ b/contents/components/other/close-button/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`CloseButton`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`CloseButton`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 `CloseButton`は、[Button](/components/forms/button)のスタイルを継承しています。

--- a/contents/components/other/close-button/theming.mdx
+++ b/contents/components/other/close-button/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `CloseButton` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `CloseButton` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 `CloseButton` inherits the style from [Button](/components/forms/button).

--- a/contents/components/overlay/dialog/theming.ja.mdx
+++ b/contents/components/overlay/dialog/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Dialog`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Dialog`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 `Dialog`は、[Modal](/components/overlay/modal)のスタイルを継承しています。

--- a/contents/components/overlay/dialog/theming.mdx
+++ b/contents/components/overlay/dialog/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Dialog` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Dialog` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 `Dialog` inherits the style from [Modal](/components/overlay/modal).

--- a/contents/components/overlay/drawer/theming.ja.mdx
+++ b/contents/components/overlay/drawer/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Drawer`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Drawer`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 `Drawer`は、[Modal](/components/overlay/modal)のスタイルを継承しています。

--- a/contents/components/overlay/drawer/theming.mdx
+++ b/contents/components/overlay/drawer/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Drawer` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Drawer` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 `Drawer` inherits the style from [Modal](/components/overlay/modal).

--- a/contents/components/overlay/menu/theming.ja.mdx
+++ b/contents/components/overlay/menu/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Menu`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Menu`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/overlay/menu/theming.mdx
+++ b/contents/components/overlay/menu/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Menu` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Menu` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/overlay/modal/theming.ja.mdx
+++ b/contents/components/overlay/modal/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Modal`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Modal`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/overlay/modal/theming.mdx
+++ b/contents/components/overlay/modal/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Modal` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Modal` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/overlay/popover/theming.ja.mdx
+++ b/contents/components/overlay/popover/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Popover`は、[複数パーツのコンポーネント](/styled-system/theming/component-style#複数パーツのコンポーネント)です。
+`Popover`は、[複数パーツのコンポーネント](/styled-system/theming/component-styles#複数パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/overlay/popover/theming.mdx
+++ b/contents/components/overlay/popover/theming.mdx
@@ -8,7 +8,7 @@ tab: Theming
 
 ## Theming
 
-The `Popover` is a [multi part component](/styled-system/theming/component-style#multi-part-components).
+The `Popover` is a [multi part component](/styled-system/theming/component-styles#multi-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/overlay/tooltip/theming.ja.mdx
+++ b/contents/components/overlay/tooltip/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Tooltip`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Tooltip`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/overlay/tooltip/theming.mdx
+++ b/contents/components/overlay/tooltip/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Tooltip` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Tooltip` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/components/typography/heading/theming.ja.mdx
+++ b/contents/components/typography/heading/theming.ja.mdx
@@ -8,7 +8,7 @@ tab: テーマ
 
 ## テーマ
 
-`Heading`は、[単一パーツのコンポーネント](/styled-system/theming/component-style#単一パーツのコンポーネント)です。
+`Heading`は、[単一パーツのコンポーネント](/styled-system/theming/component-styles#単一パーツのコンポーネント)です。
 
 :::note
 コンポーネントのスタイルを変更したい場合は、[こちら](/styled-system/theming/customize-theme#コンポーネントのスタイルを変更する)をご覧ください。

--- a/contents/components/typography/heading/theming.mdx
+++ b/contents/components/typography/heading/theming.mdx
@@ -10,7 +10,7 @@ tab: Theming
 
 ## Theming
 
-The `Heading` is a [single part component](/styled-system/theming/component-style#single-part-components).
+The `Heading` is a [single part component](/styled-system/theming/component-styles#single-part-components).
 
 :::note
 If you want to change the style of the component, please check [here](/styled-system/theming/customize-theme#changing-the-style-of-components).

--- a/contents/styled-system/theming/customize-theme.ja.mdx
+++ b/contents/styled-system/theming/customize-theme.ja.mdx
@@ -409,7 +409,7 @@ const Demo = () => {
 :::
 
 :::note
-Yamada UIが提供するコンポーネントに限らず、独自のカスタムコンポーネントのスタイルを作成することができます。詳しくは、[こちら](/styled-system/theming/component-style#独自のコンポーネントを作成する)をご覧ください。
+Yamada UIが提供するコンポーネントに限らず、独自のカスタムコンポーネントのスタイルを作成することができます。詳しくは、[こちら](/styled-system/theming/component-styles#独自のコンポーネントを作成する)をご覧ください。
 :::
 
 ## ユーティリティ

--- a/contents/styled-system/theming/customize-theme.mdx
+++ b/contents/styled-system/theming/customize-theme.mdx
@@ -409,7 +409,7 @@ To check the theme style of each component, please refer to the `Theming` on the
 :::
 
 :::note
-You can create styles for custom components, not just the components provided by Yamada UI. For more details, please check [here](/styled-system/theming/component-style#creating-custom-components).
+You can create styles for custom components, not just the components provided by Yamada UI. For more details, please check [here](/styled-system/theming/component-styles#creating-custom-components).
 :::
 
 ## Utility

--- a/scripts/theme-component.ts
+++ b/scripts/theme-component.ts
@@ -42,7 +42,7 @@ const LOCALE_DESC_MAP = {
       "## Theming",
       `The \`${componentName}\` is a [${
         isMulti ? "multi" : "single"
-      } part component](/styled-system/theming/component-style#${
+      } part component](/styled-system/theming/component-styles#${
         isMulti ? "multi" : "single"
       }-part-components).`,
     ]
@@ -72,7 +72,7 @@ const LOCALE_DESC_MAP = {
       "## テーマ",
       `\`${componentName}\`は、[${
         isMulti ? "複数" : "単一"
-      }パーツのコンポーネント](/styled-system/theming/component-style#${
+      }パーツのコンポーネント](/styled-system/theming/component-styles#${
         isMulti ? "複数" : "単一"
       }パーツのコンポーネント)です。`,
     ]


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #242 

## Description

It can not access to https://yamada-ui.com/styled-system/theming/component-style.
so I changed the url as follows.

```diff
- styled-system/theming/component-style
+ styled-system/theming/component-styles
```

## Current behavior
![2024-03-2710 54 25-ezgif com-video-to-gif-converter](https://github.com/yamada-ui/yamada-docs/assets/83833293/bbf64c35-9719-4e5d-8d2e-4d2280177d5e)

## New behavior
Operation locally has been confirmed to be accesible on English and Japanese Page.
![2024-03-2711 40 30-ezgif com-video-to-gif-converter (1)](https://github.com/yamada-ui/yamada-docs/assets/83833293/1dc05d05-bcdc-4d3c-ad13-cb94460e016f)


## Is this a breaking change (Yes/No):
No

## Additional Information
No