### PR TITLE
feat(music): add example page of music

### DIFF
--- a/pages/examples/music/content/components/titleblock.tsx
+++ b/pages/examples/music/content/components/titleblock.tsx
@@ -1,0 +1,26 @@
+import { VStack, Heading, Text, Divider } from "@yamada-ui/react"
+import React from "react"
+
+interface TitleBlockComponentProps {
+  title: string
+  outline: string
+}
+
+const TitleBlockComponent: React.FC<TitleBlockComponentProps> = ({
+  title,
+  outline,
+}) => {
+  return (
+    <VStack>
+      <Heading as="h2" size="md">
+        {title}
+      </Heading>
+      <Text fontSize="sm" color="gray">
+        {outline}
+      </Text>
+      <Divider />
+    </VStack>
+  )
+}
+
+export default TitleBlockComponent

--- a/pages/examples/music/content/index.tsx
+++ b/pages/examples/music/content/index.tsx
@@ -1,0 +1,57 @@
+import {
+  Box,
+  SegmentedControl,
+  SegmentedControlButton,
+  Flex,
+  Button,
+  VStack,
+  Icon,
+  Spacer,
+} from "@yamada-ui/react"
+import React, { useState } from "react"
+import { LuPlusCircle } from "react-icons/lu"
+import Musicpage from "./pages/musicpage"
+import Podcastpage from "./pages/podcastpage"
+
+const Content = () => {
+  // ページの表示モードを管理するステート
+  const [mode, setMode] = useState("music")
+
+  return (
+    <Box p={4} w="full">
+      <Flex w="full" gap="md">
+        <SegmentedControl
+          value={mode}
+          size="sm"
+          defaultValue="music"
+          onChange={setMode} // モードが変更されたときにステートを更新
+        >
+          <SegmentedControlButton value="music">Music</SegmentedControlButton>
+          <SegmentedControlButton value="podcast">
+            Podcast
+          </SegmentedControlButton>
+          <SegmentedControlButton value="live" isDisabled>
+            Live
+          </SegmentedControlButton>
+        </SegmentedControl>
+
+        <Spacer />
+
+        <Button
+          colorScheme="primary"
+          size="sm"
+          leftIcon={<Icon as={LuPlusCircle} />}
+        >
+          Add Music
+        </Button>
+      </Flex>
+
+      {/* コンテンツ表示部分 */}
+      <VStack p={4} pt={8}>
+        {mode === "music" ? <Musicpage /> : <Podcastpage />}
+      </VStack>
+    </Box>
+  )
+}
+
+export default Content

--- a/pages/examples/music/content/pages/musicpage.tsx
+++ b/pages/examples/music/content/pages/musicpage.tsx
@@ -1,0 +1,188 @@
+import {
+  Box,
+  Text,
+  ScrollArea,
+  Card,
+  CardHeader,
+  CardBody,
+  Flex,
+  Image,
+  Center,
+} from "@yamada-ui/react"
+import TitleBlockComponent from "../components/titleblock"
+
+const Musicpage = () => {
+  return (
+    <ScrollArea h="90vh">
+      <Box>
+        <TitleBlockComponent
+          title="Listen Now"
+          outline="Top picks for you. Updated daily."
+        />
+
+        <Box p={4} overflowX="scroll" maxW="6xl">
+          <Flex gap="4">
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    maxW="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b" fontSize="md">
+                    YamadaUI
+                  </Text>
+                  <Text fontSize="sm">Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    maxW="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    maxW="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    maxW="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+          </Flex>
+        </Box>
+      </Box>
+
+      <Box pt={8}>
+        <TitleBlockComponent
+          title="Made for You"
+          outline="Your personal playlists. Updated daily."
+        />
+
+        <Box p={4} gap={4}>
+          <Flex>
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    size="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    size="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    size="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+
+            <Card variant="elevated" maxW="xs">
+              <CardHeader>
+                <Center>
+                  <Image
+                    src="https://dragon-ball-official.com/assets/img/intro/intro_1.png"
+                    size="xs"
+                    alt="CardImage"
+                  />
+                </Center>
+              </CardHeader>
+              <CardBody>
+                <Flex direction="column">
+                  <Text as="b">YamadaUI</Text>
+                  <Text>Hirotomo Yamada</Text>
+                </Flex>
+              </CardBody>
+            </Card>
+          </Flex>
+        </Box>
+      </Box>
+    </ScrollArea>
+  )
+}
+
+export default Musicpage

--- a/pages/examples/music/content/pages/musicpage.tsx
+++ b/pages/examples/music/content/pages/musicpage.tsx
@@ -105,8 +105,8 @@ const Musicpage = () => {
           outline="Your personal playlists. Updated daily."
         />
 
-        <Box p={4} gap={4}>
-          <Flex>
+        <Box p={4}>
+          <Flex gap="4">
             <Card variant="elevated" maxW="xs">
               <CardHeader>
                 <Center>

--- a/pages/examples/music/content/pages/podcastpage.tsx
+++ b/pages/examples/music/content/pages/podcastpage.tsx
@@ -1,0 +1,31 @@
+import { Text, Center, Icon, Button, Flex } from "@yamada-ui/react"
+import React from "react"
+import { LuRadioTower } from "react-icons/lu"
+import TitleBlockComponent from "../components/titleblock"
+
+const Podcastpage = () => {
+  return (
+    <>
+      <TitleBlockComponent
+        title="New Episodes"
+        outline="Your favorite podcasts. Updated daily."
+      />
+
+      <Center borderStyle="dotted" borderColor="gray" borderWidth={1} h="lg">
+        <Flex direction="column" as={Center} gap={4}>
+          <Icon as={LuRadioTower} size="5xl" />
+          <Text as="b">No episodes added</Text>
+          <Text fontSize="sm">
+            You have not added any podcasts. Add one below.
+          </Text>
+
+          <Button size="md" variant="outline">
+            Add podcast
+          </Button>
+        </Flex>
+      </Center>
+    </>
+  )
+}
+
+export default Podcastpage

--- a/pages/examples/music/header/components/menubar.tsx
+++ b/pages/examples/music/header/components/menubar.tsx
@@ -1,0 +1,180 @@
+import {
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuGroup,
+  MenuOptionItem,
+  MenuOptionGroup,
+  MenuDivider,
+  Button,
+  Wrap,
+  Box,
+} from "@yamada-ui/react"
+import React from "react"
+
+const MenuBar = () => {
+  return (
+    <Box pl={4} pt={1} pb={1}>
+      <Wrap gap={4}>
+        {/* Menuボタン */}
+        <Menu>
+          <MenuButton as={Button} variant="ghost" colorScheme="gray" size="sm">
+            Menu
+          </MenuButton>
+          <MenuList>
+            <MenuGroup title="about">
+              <MenuItem>About Music</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="preferences">
+              <MenuItem command="⌘,">Preferences...</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="actions">
+              <MenuItem command="⌘H">Hide Music...</MenuItem>
+              <MenuItem command="↑⌘H">Hide Others...</MenuItem>
+              <MenuItem command="⌘Q">Quit Music</MenuItem>
+            </MenuGroup>
+          </MenuList>
+        </Menu>
+
+        {/* Fileボタン */}
+        <Menu>
+          <MenuButton as={Button} variant="ghost" colorScheme="gray" size="sm">
+            File
+          </MenuButton>
+          <MenuList>
+            <MenuGroup title="actions">
+              <MenuItem command=">">New</MenuItem>
+              <MenuItem command="⌘U">Open Stream URL...</MenuItem>
+              <MenuItem command="⌘W">Close Window</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="datas">
+              <MenuItem command=">">Library</MenuItem>
+              <MenuItem command="⌘O">Import...</MenuItem>
+              <MenuItem isDisabled>Burn Playlist to Disc...</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="files">
+              <MenuItem command="↑⌘R">Show in Finder</MenuItem>
+              <MenuItem>Convert</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="pages">
+              <MenuItem>Page Setup...</MenuItem>
+              <MenuItem command="⌘P" isDisabled>
+                Print...
+              </MenuItem>
+            </MenuGroup>
+          </MenuList>
+        </Menu>
+
+        {/* Editボタン */}
+        <Menu>
+          <MenuButton as={Button} variant="ghost" colorScheme="gray" size="sm">
+            Edit
+          </MenuButton>
+          <MenuList>
+            <MenuGroup title="action-options">
+              <MenuItem command="⌘Z" isDisabled>
+                Undo
+              </MenuItem>
+              <MenuItem command="↑⌘Z" isDisabled>
+                Redo
+              </MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="file-actions">
+              <MenuItem command="⌘X" isDisabled>
+                Cut
+              </MenuItem>
+              <MenuItem command="⌘C" isDisabled>
+                Copy
+              </MenuItem>
+              <MenuItem command="⌘V" isDisabled>
+                Paste
+              </MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="select-options">
+              <MenuItem command="⌘A">Select All</MenuItem>
+              <MenuItem command="↑⌘A" isDisabled>
+                Deselect All
+              </MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuGroup title="others">
+              <MenuItem>Smart Dictation...</MenuItem>
+              <MenuItem>Emoji & Symbols</MenuItem>
+            </MenuGroup>
+          </MenuList>
+        </Menu>
+
+        {/* Viewボタン */}
+        <Menu>
+          <MenuButton as={Button} variant="ghost" colorScheme="gray" size="sm">
+            View
+          </MenuButton>
+          <MenuList>
+            <MenuOptionGroup title="order" type="radio" defaultValue="option2">
+              <MenuOptionItem value="option1">Show Playing Next</MenuOptionItem>
+              <MenuOptionItem value="option2">Show Lyrics</MenuOptionItem>
+            </MenuOptionGroup>
+            <MenuDivider />
+
+            <MenuOptionGroup title="status-bar">
+              <MenuOptionItem isDisabled>Show Status Bar</MenuOptionItem>
+            </MenuOptionGroup>
+            <MenuDivider />
+
+            <MenuOptionGroup title="sidebar">
+              <MenuOptionItem>Hide Sidebar</MenuOptionItem>
+              <MenuOptionItem isDisabled>Enter Full Screen</MenuOptionItem>
+            </MenuOptionGroup>
+          </MenuList>
+        </Menu>
+
+        {/* Accountボタン */}
+        <Menu>
+          <MenuButton as={Button} variant="ghost" colorScheme="gray" size="sm">
+            Account
+          </MenuButton>
+          <MenuList>
+            <MenuGroup title="title">
+              <MenuOptionItem>Switch Account</MenuOptionItem>
+            </MenuGroup>
+            <MenuDivider />
+
+            <MenuOptionGroup title="user" type="radio" defaultValue="user2">
+              <MenuOptionItem value="user1">Andy</MenuOptionItem>
+              <MenuOptionItem value="user2">Benoit</MenuOptionItem>
+              <MenuOptionItem value="user3">Luis</MenuOptionItem>
+            </MenuOptionGroup>
+            <MenuDivider />
+
+            <MenuOptionGroup title="management">
+              <MenuOptionItem>Manage Family...</MenuOptionItem>
+            </MenuOptionGroup>
+            <MenuDivider />
+
+            <MenuOptionGroup title="account">
+              <MenuOptionItem>Add Account...</MenuOptionItem>
+            </MenuOptionGroup>
+          </MenuList>
+        </Menu>
+      </Wrap>
+    </Box>
+  )
+}
+
+export default MenuBar

--- a/pages/examples/music/header/index.tsx
+++ b/pages/examples/music/header/index.tsx
@@ -1,0 +1,14 @@
+import { Divider } from "@yamada-ui/react"
+import React from "react"
+import MenuBar from "./components/menubar"
+
+const Header = () => {
+  return (
+    <>
+      <MenuBar />
+      <Divider />
+    </>
+  )
+}
+
+export default Header

--- a/pages/examples/music/index.tsx
+++ b/pages/examples/music/index.tsx
@@ -1,14 +1,19 @@
-import { Center, Text } from "@yamada-ui/react"
+import { Flex, Divider, VStack } from "@yamada-ui/react"
 import { memo } from "react"
-// import { useI18n } from "contexts/i18n-context"
+import Content from "./content/index"
+import Header from "./header/index"
+import Sidemenu from "./sidemenu/index"
 
 export const Music = memo(() => {
-  // const { t } = useI18n()
-
   return (
-    <Center minH="lg">
-      <Text color="muted">Coming soon!</Text>
-    </Center>
+    <VStack gap={0}>
+      <Header />
+      <Flex gap="md" h="100vh">
+        <Sidemenu />
+        <Divider orientation="vertical" variant="solid" />
+        <Content />
+      </Flex>
+    </VStack>
   )
 })
 

--- a/pages/examples/music/sidemenu/index.tsx
+++ b/pages/examples/music/sidemenu/index.tsx
@@ -1,0 +1,149 @@
+import { Box, Button, ButtonGroup, Text, Flex, Icon } from "@yamada-ui/react"
+import React from "react"
+import { BsMusicNoteList } from "react-icons/bs"
+import { FaRegCirclePlay } from "react-icons/fa6"
+import { IoIosRadio, IoIosBrowsers } from "react-icons/io"
+import { IoPersonOutline } from "react-icons/io5"
+import { LuMusic2, LuMic2 } from "react-icons/lu"
+import { MdAlbum } from "react-icons/md"
+
+const Sidemenu = () => {
+  return (
+    <>
+      <Box pl={8}>
+        <Flex direction="column">
+          <Flex direction="column" pt={4}>
+            <Text as="b" fontSize="lg">
+              Discover
+            </Text>
+            <ButtonGroup
+              variant="ghost"
+              colorScheme="neutral"
+              size="sm"
+              direction="column"
+            >
+              <Button
+                leftIcon={<Icon as={FaRegCirclePlay} />}
+                justifyContent="flex-start"
+              >
+                <Text>Listen Now</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={IoIosBrowsers} />}
+                justifyContent="flex-start"
+              >
+                <Text>Browse</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={IoIosRadio} />}
+                justifyContent="flex-start"
+              >
+                <Text>Radio</Text>
+              </Button>
+            </ButtonGroup>
+          </Flex>
+
+          <Flex direction="column" pt={4}>
+            <Text as="b" fontSize="lg">
+              Library
+            </Text>
+            <ButtonGroup
+              variant="ghost"
+              colorScheme="neutral"
+              size="sm"
+              direction="column"
+            >
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Playlists</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={LuMusic2} />}
+                justifyContent="flex-start"
+              >
+                <Text>Songs</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={IoPersonOutline} />}
+                justifyContent="flex-start"
+              >
+                <Text>Made for you</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={LuMic2} />}
+                justifyContent="flex-start"
+              >
+                <Text>Artists</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={MdAlbum} />}
+                justifyContent="flex-start"
+              >
+                <Text>Albums</Text>
+              </Button>
+            </ButtonGroup>
+          </Flex>
+
+          <Flex direction="column" pt={4}>
+            <Text as="b" fontSize="lg">
+              Playlists
+            </Text>
+            <ButtonGroup
+              variant="ghost"
+              colorScheme="neutral"
+              size="sm"
+              direction="column"
+            >
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Recently Added</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Recently Played</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Top Songs</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Top Albums</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Top Artists</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Logic Discography</Text>
+              </Button>
+              <Button
+                leftIcon={<Icon as={BsMusicNoteList} />}
+                justifyContent="flex-start"
+              >
+                <Text>Bedtime Beats</Text>
+              </Button>
+            </ButtonGroup>
+          </Flex>
+        </Flex>
+      </Box>
+    </>
+  )
+}
+
+export default Sidemenu


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #210 

## Description
Add Example Page of Music

## Current behavior (updates)
You can not see the example of how to use YamadaUI for Music Page.

## New behavior
You can see the example of how to use YamadaUI for Music Page.

## Is this a breaking change (Yes/No):
Maybe not.

## Additional Information
